### PR TITLE
Fix not being able to select with mouse click on highlighted line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,7 @@
 **Released: WiP**
 
 - Fixed not being able to navigate into a child entry by mouse-clicking on a
-  highlighted line.
+  highlighted line. ([#11](https://github.com/davep/aging/pull/11))
 
 ## v0.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,12 @@
 # Aging ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- Fixed not being able to navigate into a child entry by mouse-clicking on a
+  highlighted line.
+
 ## v0.1.0
 
 **Released: 2025-03-11**

--- a/src/aging/widgets/entry_viewer/entry_content.py
+++ b/src/aging/widgets/entry_viewer/entry_content.py
@@ -305,6 +305,12 @@ class EntryContent(EnhancedOptionList):
         if self.scroll_offset.y + y == self.highlighted:
             if highlight := self.get_visual_style("option-list--option-highlighted"):
                 highlight_style = highlight.rich_style
+                # Despite its name, Style.without_color removes more than
+                # colour; one of the things it removes it `meta`. The
+                # OptionList uses meta to know which option was clicked on.
+                # So we need to peek into the highlight strip and pull out
+                # an example of the style so we can get the meta for later.
+                borrowed_style = next(iter(strip)).style
                 strip = Strip(
                     [
                         Segment(
@@ -317,7 +323,13 @@ class EntryContent(EnhancedOptionList):
                         for text, style, control in strip
                     ]
                 ).simplify()
-
+                # So here, if we have a borrowed style, and if it has meta
+                # information, we apply it to the new strip we created so
+                # that the `option` value is retained. Without it the user
+                # wouldn't be able to cause an `OptionSelected` message from
+                # clicking on a highlighted option.
+                if borrowed_style is not None and borrowed_style.meta:
+                    strip = strip.apply_meta(borrowed_style.meta)
         return strip
 
 


### PR DESCRIPTION
The workaround I have in the entry viewer, to make the highlight colour take priority over the text colours, caused a problem with selecting a linkable line when the line already had the highlight. Clicking on the highlighted line would do nothing.

Turns out `Style.without_color`, [despite its name and description](https://rich.readthedocs.io/en/stable/reference/style.html?highlight=without_color#rich.style.Style.without_color), gives a style that's sans a wee bit more than just colour styling -- it also strips the `meta` too.

This PR adds a workaround for that.