### PR TITLE
Add guide directory management

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,6 +6,12 @@
 
 - Fixed not being able to navigate into a child entry by mouse-clicking on a
   highlighted line. ([#11](https://github.com/davep/aging/pull/11))
+- Added the ability to rename the title of a guide as it appears in the
+  guide directory. ([#13](https://github.com/davep/aging/pull/13))
+- Added the ability to remove a guide from the guide directory.
+  ([#13](https://github.com/davep/aging/pull/13))
+- Added the ability to remove all guides from the guide directory.
+  ([#13](https://github.com/davep/aging/pull/13))
 
 ## v0.1.0
 

--- a/src/aging/messages/__init__.py
+++ b/src/aging/messages/__init__.py
@@ -3,11 +3,11 @@
 ##############################################################################
 # Local imports.
 from .clipboard import CopyToClipboard
-from .main import OpenEntry, OpenGuide
+from .main import GuidesUpdated, OpenEntry, OpenGuide
 
 ##############################################################################
 # Exports.
-__all__ = ["CopyToClipboard", "OpenEntry", "OpenGuide"]
+__all__ = ["CopyToClipboard", "GuidesUpdated", "OpenEntry", "OpenGuide"]
 
 
 ### __init__.py ends here

--- a/src/aging/messages/main.py
+++ b/src/aging/messages/main.py
@@ -34,4 +34,9 @@ class OpenEntry(Message):
     """The optional line to highlight once the entry is opened."""
 
 
+##############################################################################
+class GuidesUpdated(Message):
+    """Message sent when the guide directory has been updated."""
+
+
 ### main.py ends here

--- a/src/aging/providers/guides.py
+++ b/src/aging/providers/guides.py
@@ -28,7 +28,7 @@ class GuidesCommands(CommandsProvider):
         Yields:
             Commands to show in the command palette.
         """
-        for guide in self.guides:
+        for guide in sorted(self.guides):
             yield CommandHit(
                 f"{guide.title} ({guide.location.name})",
                 f"Open and view {guide.location.name}",

--- a/src/aging/screens/main.py
+++ b/src/aging/screens/main.py
@@ -63,7 +63,7 @@ from ..data import (
     save_guides,
     update_configuration,
 )
-from ..messages import CopyToClipboard, OpenEntry, OpenGuide
+from ..messages import CopyToClipboard, GuidesUpdated, OpenEntry, OpenGuide
 from ..providers import GuidesCommands, MainCommands
 from ..widgets import EntryViewer, GuideDirectory, GuideMenu
 from .about import About
@@ -349,6 +349,11 @@ class Main(EnhancedScreen[None]):
         ):
             return self.entry is not None
         return True
+
+    @on(GuidesUpdated)
+    def _reload_guides(self) -> None:
+        """Reaload the guide directory from storage."""
+        self.guides = load_guides()
 
     @on(AddGuidesToDirectory)
     @work

--- a/src/aging/screens/main.py
+++ b/src/aging/screens/main.py
@@ -282,7 +282,7 @@ class Main(EnhancedScreen[None]):
         # duplicates based on title are fine and it's up to the user to
         # decide if they want to remove them or not.
         if guides := [guide for guide in guides if guide.location not in self.guides]:
-            self.guides = sorted(self.guides + guides)
+            self.guides = self.guides + guides
             save_guides(self.guides)
             self.notify(f"New guides scanned and added: {len(guides)}")
         else:

--- a/src/aging/widgets/guide_directory.py
+++ b/src/aging/widgets/guide_directory.py
@@ -76,7 +76,18 @@ class GuideDirectory(EnhancedOptionList):
         Binding(
             "r", "rename", "Rename", tooltip="Rename the title of the highlighted guide"
         ),
-        Binding("delete", "remove", "Remove", tooltip="Remove the highlighted guide"),
+        Binding(
+            "delete",
+            "remove",
+            "Remove",
+            tooltip="Remove the highlighted guide from the directory",
+        ),
+        Binding(
+            "ctrl+delete",
+            "remove_all",
+            "Remove all",
+            tooltip="Remove all guides from the directory",
+        ),
     ]
 
     dock_right: var[bool] = var(False)
@@ -141,6 +152,8 @@ class GuideDirectory(EnhancedOptionList):
         """
         if self.is_mounted:
             if action in ("rename", "remove"):
+                return self.highlighted is not None
+            if action == "remove_all":
                 return bool(self.guides)
         return True
 
@@ -213,6 +226,17 @@ class GuideDirectory(EnhancedOptionList):
             guides = self.guides.copy()
             del guides[guide_index]
             self._refresh_guides(guides)
+
+    @work
+    async def action_remove_all(self) -> None:
+        """Remove all guides from the directory."""
+        if await self.app.push_screen_wait(
+            Confirm(
+                "Remove all?",
+                "Are you sure you want to remove all guides from the directory?",
+            )
+        ):
+            self._refresh_guides([])
 
 
 ### guide_directory.py ends here

--- a/src/aging/widgets/guide_directory.py
+++ b/src/aging/widgets/guide_directory.py
@@ -72,7 +72,12 @@ class GuideDirectory(EnhancedOptionList):
     to the application.
     """
 
-    BINDINGS = [Binding("r", "rename", "Rename"), Binding("delete", "remove", "Remove")]
+    BINDINGS = [
+        Binding(
+            "r", "rename", "Rename", tooltip="Rename the title of the highlighted guide"
+        ),
+        Binding("delete", "remove", "Remove", tooltip="Remove the highlighted guide"),
+    ]
 
     dock_right: var[bool] = var(False)
     """Should the directory dock to the right?"""


### PR DESCRIPTION
Provides the ability to:

- [x] Rename the title of a guide in the directory
- [x] Remove an individual guide from the directory
- [x] Remove all guides from the directory

TODO:

- [x] Ensure that the sorting either only happens in one place, or is only for visual purposes.

Closes #2.