### PR TITLE
Make some locations "sticky"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,8 +13,11 @@
 - Added the ability to remove all guides from the guide directory.
   ([#13](https://github.com/davep/aging/pull/13))
 - The dialog for adding guides to the guide directory now remembers the
-  last-selected directory, and starts from there on next use
-  (#14[](https://github.com/davep/aging/pull/14)).
+  last-selected directory, and starts from there on next use.
+  (#14[](https://github.com/davep/aging/pull/14))
+- When browsing to open an individual guide from the filesystem the
+  application remembers the last location a guide was opened from and starts
+  there. (#14[](https://github.com/davep/aging/pull/14))
 
 ## v0.1.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -12,6 +12,9 @@
   ([#13](https://github.com/davep/aging/pull/13))
 - Added the ability to remove all guides from the guide directory.
   ([#13](https://github.com/davep/aging/pull/13))
+- The dialog for adding guides to the guide directory now remembers the
+  last-selected directory, and starts from there on next use
+  (#14[](https://github.com/davep/aging/pull/14)).
 
 ## v0.1.0
 

--- a/src/aging/data/config.py
+++ b/src/aging/data/config.py
@@ -40,6 +40,9 @@ class Configuration:
     last_added_guides_from: str = "."
     """The location the user last added guides from."""
 
+    last_opened_guide_from: str = "."
+    """The location the user last browsed for an individual guide from."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/aging/data/config.py
+++ b/src/aging/data/config.py
@@ -37,6 +37,9 @@ class Configuration:
     classic_view: bool = False
     """Should the entry view use a classic Norton Guide colour scheme?"""
 
+    last_added_guides_from: str = "."
+    """The location the user last added guides from."""
+
 
 ##############################################################################
 def configuration_file() -> Path:

--- a/src/aging/screens/main.py
+++ b/src/aging/screens/main.py
@@ -606,13 +606,16 @@ class Main(EnhancedScreen[None]):
         if (
             guide := await self.app.push_screen_wait(
                 FileOpen(
+                    Path(load_configuration().last_opened_guide_from),
                     filters=Filters(
                         ("Norton Guides", lambda p: p.suffix.lower() == ".ng")
-                    )
+                    ),
                 )
             )
         ) is not None:
             self.post_message(OpenGuide(guide))
+            with update_configuration() as config:
+                config.last_opened_guide_from = str(guide.parent)
 
     @on(SearchForGuide)
     def action_search_for_guide_command(self) -> None:

--- a/src/aging/screens/main.py
+++ b/src/aging/screens/main.py
@@ -295,6 +295,8 @@ class Main(EnhancedScreen[None]):
         Args:
             directory: The directory to scan for Norton Guides.
         """
+        with update_configuration() as config:
+            config.last_added_guides_from = str(directory.resolve())
         worker = get_current_worker()
         guides: list[Guide] = []
         for candidate in directory.glob("**/*.*"):
@@ -360,7 +362,10 @@ class Main(EnhancedScreen[None]):
     async def action_add_guides_to_directory_command(self) -> None:
         """Let the user add more guides to the guide directory."""
         if add_from := await self.app.push_screen_wait(
-            SelectDirectory(title="Add Norton Guides From...")
+            SelectDirectory(
+                Path(load_configuration().last_added_guides_from),
+                title="Add Norton Guides From...",
+            )
         ):
             self._add_guides_from(add_from)
 


### PR DESCRIPTION
When adding new guides or opening a guide, more often than not the desired starting location is going to be at or close to the last time this was done. So let's make those locations sticky...