### PR TITLE
Tidy up help around the guide directory

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "textual>=2.1.2",
-    "textual-enhanced>=0.7.1",
+    "textual-enhanced>=0.8.1",
     "ngdb>=0.9.0",
     "typing-extensions>=4.12.2",
     "xdg-base-dirs>=6.0.2",

--- a/requirements-dev.lock
+++ b/requirements-dev.lock
@@ -89,7 +89,7 @@ textual==2.1.2
     # via textual-fspicker
     # via textual-serve
 textual-dev==1.7.0
-textual-enhanced==0.7.1
+textual-enhanced==0.8.1
     # via aging
 textual-fspicker==0.4.1
     # via aging

--- a/requirements.lock
+++ b/requirements.lock
@@ -36,7 +36,7 @@ textual==2.1.2
     # via aging
     # via textual-enhanced
     # via textual-fspicker
-textual-enhanced==0.7.1
+textual-enhanced==0.8.1
     # via aging
 textual-fspicker==0.4.1
     # via aging

--- a/src/aging/widgets/guide_directory.py
+++ b/src/aging/widgets/guide_directory.py
@@ -18,6 +18,7 @@ from textual.widgets.option_list import Option, OptionDoesNotExist
 
 ##############################################################################
 # Textual enhanced imports.
+from textual_enhanced.binding import HelpfulBinding
 from textual_enhanced.dialogs import Confirm, ModalInput
 from textual_enhanced.widgets import EnhancedOptionList
 
@@ -73,20 +74,26 @@ class GuideDirectory(EnhancedOptionList):
     """
 
     BINDINGS = [
-        Binding(
-            "r", "rename", "Rename", tooltip="Rename the title of the highlighted guide"
+        HelpfulBinding(
+            "r",
+            "rename",
+            "Rename",
+            tooltip="Rename the title of the highlighted guide",
+            show=False,
         ),
-        Binding(
+        HelpfulBinding(
             "delete",
             "remove",
             "Remove",
             tooltip="Remove the highlighted guide from the directory",
+            show=False,
         ),
-        Binding(
+        HelpfulBinding(
             "ctrl+delete",
             "remove_all",
             "Remove all",
             tooltip="Remove all guides from the directory",
+            show=False,
         ),
     ]
 


### PR DESCRIPTION
Declutter the `Footer` and lean into some changes I've made to the textual-enhanced help screen.