### PR TITLE
Fully hide the menu pane if there are zero menus

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -13,6 +13,7 @@
   ([#18](https://github.com/davep/aging/pull/18))
 - Improved handling of corrupted/truncated guides, ensuring the app shows an
   error to the user rather than crashing.
+- Fully hide the menu pane if we encounter a guide that has zero menus.
 
 ## v0.2.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@
 - Improved handling of corrupted/truncated guides, ensuring the app shows an
   error to the user rather than crashing.
 - Fully hide the menu pane if we encounter a guide that has zero menus.
+  ([#24](https://github.com/davep/aging/pull/24))
 
 ## v0.2.0
 

--- a/src/aging/screens/main.py
+++ b/src/aging/screens/main.py
@@ -288,8 +288,6 @@ class Main(EnhancedScreen[None]):
             self.post_message(
                 OpenGuide(Path(config.current_guide), config.current_entry)
             )
-        if not self.guides_visible:
-            self.set_focus(self.query_one(GuideMenu))
 
     def _new_guides(self, guides: Guides) -> None:
         """Add a list of new guides to the guide directory.
@@ -424,8 +422,9 @@ class Main(EnhancedScreen[None]):
         self.guide = new_guide
 
         # Having opening the guide, the user probably wants to be in the
-        # menu.
-        self.query_one(GuideMenu).focus()
+        # menu, unless there is no menu, then we'll land on the entry
+        # viewer.
+        self.query_one(GuideMenu if self.guide.menu_count else EntryViewer).focus()
 
         # If we're being asked to jump to a specific entry, to start with,
         # make sure we're there...

--- a/src/aging/widgets/guide_menu.py
+++ b/src/aging/widgets/guide_menu.py
@@ -77,7 +77,7 @@ class GuideMenu(EnhancedOptionList):
             border: none;
         }
 
-        &.--no-guide {
+        &.--no-guide, &.--no-menu {
             display: none;
         }
     }
@@ -124,6 +124,7 @@ class GuideMenu(EnhancedOptionList):
                     )
                     for prompt_id, prompt in enumerate(menu)
                 )
+            self.set_class(not bool(self.option_count), "--no-menu")
             if not self._highlight_menu_for_current_entry():
                 self.highlighted = 0
 


### PR DESCRIPTION
Zero menus in a guide is almost unheard of; I think it might only have been possible with the Expert Help compiler, not the Norton Guide compiler. In fact the only guide I have to hand that has zero menus is the guide to Expert Help.

Fixes #19.