### PR TITLE
Give pyright a clue as to where the venv lives

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,8 @@ allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/aging"]
+
+[tool.pyright]
+venvPath="."
+venv=".venv"
+exclude=[".venv"]


### PR DESCRIPTION
This isn't really needed for my Emacs setup, but it looks like pyright needs a helping hand when using Helix, for example. Doing it this way has no negative impact on my normal workflow so I might as well do this.