### PR TITLE
Only show guides progress when searching many guides

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Aging ChangeLog
 
+## Unreleased
+
+**Released: WiP**
+
+- When doing a guide-wide search in the global search dialog, only the entry
+  progress is now shown; the guides progress is now only visible when doing
+  an all-guides search.
+
 ## v0.3.0
 
 **Released: 2025-03-22**

--- a/src/aging/screens/search.py
+++ b/src/aging/screens/search.py
@@ -236,6 +236,9 @@ class Search(ModalScreen[SearchResult]):
             .--when-stopped {
                 display: none;
             }
+            &.--running-locally .--global-only {
+                display: none;
+            }
         }
     }
     """
@@ -292,8 +295,12 @@ class Search(ModalScreen[SearchResult]):
                 yield Counter(id="lines")
                 yield Counter(id="hits")
             yield Rule(classes="--when-running")
-            yield Label(id="current_guide", classes="--when-running", markup=False)
-            yield ProgressBar(id="guides_progress", classes="--when-running")
+            yield Label(
+                id="current_guide", classes="--when-running --global-only", markup=False
+            )
+            yield ProgressBar(
+                id="guides_progress", classes="--when-running --global-only"
+            )
             yield Label(id="current_entry", classes="--when-running", markup=False)
             yield ProgressBar(id="guide_progress", classes="--when-running")
             yield Rule()
@@ -579,6 +586,7 @@ class Search(ModalScreen[SearchResult]):
             guides = [Guide(self._guide.title, self._guide.path)]
         self._search_hits = []
         self.query_one(SearchResults).clear_results()
+        self.set_class(len(guides) == 1, "--running-locally")
         self._search(
             guides,
             search_text,


### PR DESCRIPTION
When doing a "global" search, only show the name of the current guide, and the progress through the guides to search, if we're searching multiple guides.

Closes #30.